### PR TITLE
updated dhcp option policy test file

### DIFF
--- a/mso/resource_mso_dhcp_option_policy_test.go
+++ b/mso/resource_mso_dhcp_option_policy_test.go
@@ -202,8 +202,7 @@ func TestAccMSODHCPOptionPolicy_Negative(t *testing.T) {
 				ExpectError: regexp.MustCompile(`Unsupported argument`),
 			},
 			{
-				Config:      MSODHCPOptionPolicyWithRequired(randomValue, randomValue),
-				ExpectError: regexp.MustCompile(`An argument named(.)+is not expected here.`),
+				Config: MSODHCPOptionPolicyWithRequired(randomValue, randomValue),
 			},
 		},
 	})


### PR DESCRIPTION
=== RUN   TestAccMSODHCPOptionPolicyOptionDataSource_Basic
--- PASS: TestAccMSODHCPOptionPolicyOptionDataSource_Basic (25.41s)
=== RUN   TestAccMSODHCPOptionPolicy_DataSource
=== PAUSE TestAccMSODHCPOptionPolicy_DataSource
=== RUN   TestAccMSODHCPOptionPolicyOption_Basic
=== PAUSE TestAccMSODHCPOptionPolicyOption_Basic
=== RUN   TestAccMSODHCPOptionPolicyOption_Negative
=== PAUSE TestAccMSODHCPOptionPolicyOption_Negative
=== RUN   TestAccMSODHCPOptionPolicyOption_MultipleCreateDelete
=== PAUSE TestAccMSODHCPOptionPolicyOption_MultipleCreateDelete
=== RUN   TestAccMSODHCPOptionPolicy_Basic
=== PAUSE TestAccMSODHCPOptionPolicy_Basic
=== RUN   TestAccMSODHCPOptionPolicy_Update
=== PAUSE TestAccMSODHCPOptionPolicy_Update
=== RUN   TestAccMSODHCPOptionPolicy_Negative
=== PAUSE TestAccMSODHCPOptionPolicy_Negative
=== RUN   TestAccMSODHCPOptionPolicy_MultipleCreateDelete
=== PAUSE TestAccMSODHCPOptionPolicy_MultipleCreateDelete
=== CONT  TestAccMSODHCPOptionPolicy_DataSource
=== CONT  TestAccMSODHCPOptionPolicy_Basic
=== CONT  TestAccMSODHCPOptionPolicyOption_Negative
=== CONT  TestAccMSODHCPOptionPolicyOption_Basic
=== CONT  TestAccMSODHCPOptionPolicy_Negative
=== CONT  TestAccMSODHCPOptionPolicy_Update
=== CONT  TestAccMSODHCPOptionPolicy_MultipleCreateDelete
=== CONT  TestAccMSODHCPOptionPolicyOption_MultipleCreateDelete
--- PASS: TestAccMSODHCPOptionPolicy_Negative (6.81s)
--- PASS: TestAccMSODHCPOptionPolicy_MultipleCreateDelete (8.19s)
--- PASS: TestAccMSODHCPOptionPolicy_Update (9.03s)
--- PASS: TestAccMSODHCPOptionPolicy_DataSource (15.02s)
--- PASS: TestAccMSODHCPOptionPolicy_Basic (24.42s)
--- PASS: TestAccMSODHCPOptionPolicyOption_Negative (24.87s)
--- PASS: TestAccMSODHCPOptionPolicyOption_MultipleCreateDelete (26.73s)
--- PASS: TestAccMSODHCPOptionPolicyOption_Basic (49.55s)
PASS
ok      github.com/terraform-providers/terraform-provider-mso/mso       75.620s
