### PR TITLE
Schema template bd dhcp policy

### DIFF
--- a/mso/datasource_mso_schema_template_bd_dhcp_policy.go
+++ b/mso/datasource_mso_schema_template_bd_dhcp_policy.go
@@ -1,7 +1,6 @@
 package mso
 
 import (
-	"fmt"
 	"log"
 
 	"github.com/ciscoecosystem/mso-go-client/client"
@@ -66,7 +65,6 @@ func datasourceMSOTemplateBDDHCPPolicyRead(d *schema.ResourceData, m interface{}
 	if err != nil {
 		return err
 	}
-	fmt.Printf("remoteBDDHCPPolicy: %v\n", remoteBDDHCPPolicy)
 	setMSOTemplateBDDHCPPolicy(d, remoteBDDHCPPolicy)
 
 	d.SetId(createMSOTemplateBDDHCPPolicyId(&bdDHCPPolicy))

--- a/mso/datasource_mso_schema_template_bd_dhcp_policy_test.go
+++ b/mso/datasource_mso_schema_template_bd_dhcp_policy_test.go
@@ -1,0 +1,174 @@
+package mso
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/mso-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccMSOSchemaTemplateBDDHCPPolicy_DataSource(t *testing.T) {
+	var pol1 models.TemplateBDDHCPPolicy
+	schema := makeTestVariable(acctest.RandString(5))
+	name := makeTestVariable(acctest.RandString(5))
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+	resourceName := "mso_schema_template_bd_dhcp_policy.test"
+	dataSourceName := "data.mso_schema_template_bd_dhcp_policy.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckMSOSchemaTemplateBDDHCPDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateMSOSchemaTemplateBDDHCPPolicyDataSourceWithoutRequired(tenantNames[0], schema, name, "schema_id"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateMSOSchemaTemplateBDDHCPPolicyDataSourceWithoutRequired(tenantNames[0], schema, name, "template_name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateMSOSchemaTemplateBDDHCPPolicyDataSourceWithoutRequired(tenantNames[0], schema, name, "bd_name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateMSOSchemaTemplateBDDHCPPolicyDataSourceWithoutRequired(tenantNames[0], schema, name, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateMSOSchemaTemplateBDDHCPPolicyDataSourceWithInvalidParentResourceName(tenantNames[0], schema, name),
+				ExpectError: regexp.MustCompile(`Object Not found`),
+			},
+			{
+				Config:      CreateMSOSchemaTemplateBDDHCPPolicyDataSourceWithRandomAttr(tenantNames[0], schema, name, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named(.)+is not expected here.`),
+			},
+			{
+				Config: CreateMSOSchemaTemplateBDDHCPPolicyDataSourceWithRequired(tenantNames[0], schema, name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMSOSchemaTemplateBDDHCPPolicyExists(resourceName, &pol1),
+					resource.TestCheckResourceAttrPair(resourceName, "bd_name", dataSourceName, "bd_name"),
+					resource.TestCheckResourceAttrPair(resourceName, "name", dataSourceName, "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "template_name", dataSourceName, "template_name"),
+					resource.TestCheckResourceAttrPair(resourceName, "dhcp_option_name", dataSourceName, "dhcp_option_name"),
+					resource.TestCheckResourceAttrPair(resourceName, "dhcp_option_version", dataSourceName, "dhcp_option_version"),
+					resource.TestCheckResourceAttrPair(resourceName, "version", dataSourceName, "version"),
+					resource.TestCheckResourceAttrPair(resourceName, "schema_id", dataSourceName, "schema_id"),
+				),
+			},
+		},
+	})
+}
+
+func CreateMSOSchemaTemplateBDDHCPPolicyDataSourceWithRandomAttr(tenant, schema, name, key, value string) string {
+	resource := GetParentConfigBDDHCPPolicy(tenant, schema, name)
+	resource += fmt.Sprintf(`
+	resource "mso_schema_template_bd_dhcp_policy" "test" {
+		schema_id           = mso_schema.test.id
+		template_name       = mso_schema.test.template_name
+		bd_name             = mso_schema_template_bd.test.name
+		name                = mso_dhcp_relay_policy.test.name
+	}
+	data "mso_schema_template_bd_dhcp_policy" "test" {
+		schema_id           = mso_schema_template_bd_dhcp_policy.test.schema_id
+		template_name       = mso_schema_template_bd_dhcp_policy.test.template_name
+		bd_name             = mso_schema_template_bd_dhcp_policy.test.bd_name
+		name                = mso_schema_template_bd_dhcp_policy.test.name
+		%s                  = "%s"
+	}
+	`, key, value)
+	return resource
+}
+
+func CreateMSOSchemaTemplateBDDHCPPolicyDataSourceWithInvalidParentResourceName(tenant, schema, name string) string {
+	resource := GetParentConfigBDDHCPPolicy(tenant, schema, name)
+	resource += fmt.Sprintln(`
+	resource "mso_schema_template_bd_dhcp_policy" "test" {
+		schema_id           = mso_schema.test.id
+		template_name       = mso_schema.test.template_name
+		bd_name             = mso_schema_template_bd.test.name
+		name                = mso_dhcp_relay_policy.test.name
+	}
+	data "mso_schema_template_bd_dhcp_policy" "test" {
+		schema_id           = mso_schema_template_bd_dhcp_policy.test.schema_id
+		template_name       = mso_schema_template_bd_dhcp_policy.test.template_name
+		bd_name             = "${mso_schema_template_bd_dhcp_policy.test.bd_name}_invalid"
+		name                = mso_schema_template_bd_dhcp_policy.test.name
+	}
+	`)
+	return resource
+}
+
+func CreateMSOSchemaTemplateBDDHCPPolicyDataSourceWithRequired(tenant, schema, name string) string {
+	resource := GetParentConfigBDDHCPPolicy(tenant, schema, name)
+	resource += fmt.Sprintln(`
+	resource "mso_schema_template_bd_dhcp_policy" "test" {
+		schema_id           = mso_schema.test.id
+		template_name       = mso_schema.test.template_name
+		bd_name             = mso_schema_template_bd.test.name
+		name                = mso_dhcp_relay_policy.test.name
+	}
+	data "mso_schema_template_bd_dhcp_policy" "test" {
+		schema_id           = mso_schema_template_bd_dhcp_policy.test.schema_id
+		template_name       = mso_schema_template_bd_dhcp_policy.test.template_name
+		bd_name             = mso_schema_template_bd_dhcp_policy.test.bd_name
+		name                = mso_schema_template_bd_dhcp_policy.test.name
+	}
+	`)
+	return resource
+}
+
+func CreateMSOSchemaTemplateBDDHCPPolicyDataSourceWithoutRequired(tenant, schema, name, attr string) string {
+	rBlock := GetParentConfigBDDHCPPolicy(tenant, schema, name)
+	rBlock += `
+	resource "mso_schema_template_bd_dhcp_policy" "test" {
+		schema_id           = mso_schema.test.id
+		template_name       = mso_schema.test.template_name
+		bd_name             = mso_schema_template_bd.test.name
+		name                = mso_dhcp_relay_policy.test.name
+	}
+	`
+	switch attr {
+	case "schema_id":
+		rBlock += `
+		data "mso_schema_template_bd_dhcp_policy" "test" {
+		#	schema_id           = mso_schema_template_bd_dhcp_policy.test.schema_id
+			template_name       = mso_schema_template_bd_dhcp_policy.test.template_name
+			bd_name             = mso_schema_template_bd_dhcp_policy.test.bd_name
+			name                = mso_schema_template_bd_dhcp_policy.test.name
+		}
+		`
+	case "template_name":
+		rBlock += `
+		data "mso_schema_template_bd_dhcp_policy" "test" {
+			schema_id           = mso_schema_template_bd_dhcp_policy.test.schema_id
+		#	template_name       = mso_schema_template_bd_dhcp_policy.test.template_name
+			bd_name             = mso_schema_template_bd_dhcp_policy.test.bd_name
+			name                = mso_schema_template_bd_dhcp_policy.test.name
+		}
+		`
+	case "bd_name":
+		rBlock += `
+		data "mso_schema_template_bd_dhcp_policy" "test" {
+			schema_id           = mso_schema_template_bd_dhcp_policy.test.schema_id
+			template_name       = mso_schema_template_bd_dhcp_policy.test.template_name
+		#	bd_name             = mso_schema_template_bd_dhcp_policy.test.bd_name
+			name                = mso_schema_template_bd_dhcp_policy.test.name
+		}
+		`
+	case "name":
+		rBlock += `
+		data "mso_schema_template_bd_dhcp_policy" "test" {
+			schema_id           = mso_schema_template_bd_dhcp_policy.test.schema_id
+			template_name       = mso_schema_template_bd_dhcp_policy.test.template_name
+			bd_name             = mso_schema_template_bd_dhcp_policy.test.bd_name
+		#	name                = mso_schema_template_bd_dhcp_policy.test.name
+		}
+		`
+	}
+	return fmt.Sprintln(rBlock)
+}

--- a/mso/provider_test.go
+++ b/mso/provider_test.go
@@ -57,6 +57,48 @@ func CreateDHCPRelayPolicy(tenant, polname string) string {
 	return resource
 }
 
+func GetParentConfigBDDHCPPolicy(tenant,schema,name string)string{
+	resource:=fmt.Sprintf(`
+	data "mso_tenant" "test" {
+		name         = "%s"
+		display_name = "%s"
+	}
+	  
+	 resource "mso_schema" "test" {
+		name          = "%s"
+		template_name = "%s"
+		tenant_id     = data.mso_tenant.test.id
+	}
+	  
+	resource "mso_schema_template_vrf" "test" {
+		schema_id        = mso_schema.test.id
+		template         = mso_schema.test.template_name
+		name             = "%s"
+		display_name     = "%s"
+	}
+	  
+	resource "mso_schema_template_bd" "test" {
+		schema_id              = mso_schema.test.id
+		template_name          = mso_schema.test.template_name
+		name                   = "%s"
+		display_name           = "%s"
+		vrf_name               = mso_schema_template_vrf.test.name
+	}
+	  
+	resource "mso_dhcp_relay_policy" "test" {
+		tenant_id   = data.mso_tenant.test.id
+		name        = "%s"
+	}
+	  
+	resource "mso_schema_template_bd_dhcp_policy" "test" {
+		schema_id           = mso_schema.test.id
+		template_name       = mso_schema.test.template_name
+		bd_name             = mso_schema_template_bd.test.name
+		name                = mso_dhcp_relay_policy.test.name
+	  }
+	`)
+}
+
 func init() {
 	testAccProvider = Provider().(*schema.Provider)
 	testAccProviders = map[string]terraform.ResourceProvider{

--- a/mso/provider_test.go
+++ b/mso/provider_test.go
@@ -57,8 +57,8 @@ func CreateDHCPRelayPolicy(tenant, polname string) string {
 	return resource
 }
 
-func GetParentConfigBDDHCPPolicy(tenant,schema,name string)string{
-	resource:=fmt.Sprintf(`
+func GetParentConfigBDDHCPPolicy(tenant, schema, name string) string {
+	resource := fmt.Sprintf(`
 	data "mso_tenant" "test" {
 		name         = "%s"
 		display_name = "%s"
@@ -89,14 +89,8 @@ func GetParentConfigBDDHCPPolicy(tenant,schema,name string)string{
 		tenant_id   = data.mso_tenant.test.id
 		name        = "%s"
 	}
-	  
-	resource "mso_schema_template_bd_dhcp_policy" "test" {
-		schema_id           = mso_schema.test.id
-		template_name       = mso_schema.test.template_name
-		bd_name             = mso_schema_template_bd.test.name
-		name                = mso_dhcp_relay_policy.test.name
-	  }
-	`)
+	`, tenant, tenant, schema, schema, name, name, name, name, name)
+	return resource
 }
 
 func init() {

--- a/mso/resource_mso_schema_template_bd_dhcp_policy.go
+++ b/mso/resource_mso_schema_template_bd_dhcp_policy.go
@@ -192,7 +192,6 @@ func resourceMSOTemplateBDDHCPPolicyRead(d *schema.ResourceData, m interface{}) 
 		d.SetId("")
 		return nil
 	}
-	fmt.Printf("remoteBDDHCPPolicy: %v\n", remoteBDDHCPPolicy)
 	setMSOTemplateBDDHCPPolicy(d, remoteBDDHCPPolicy)
 
 	d.SetId(

--- a/mso/resource_mso_schema_template_bd_dhcp_policy_test.go
+++ b/mso/resource_mso_schema_template_bd_dhcp_policy_test.go
@@ -2,6 +2,7 @@ package mso
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/ciscoecosystem/mso-go-client/client"
@@ -13,23 +14,144 @@ import (
 
 func TestAccMSOSchemaTemplateBDDHCPPolicy_Basic(t *testing.T) {
 	var pol1 models.TemplateBDDHCPPolicy
-	schema:=makeTestVariable(acctest.RandString(5))
-	name:=makeTestVariable(acctest.RandString(5))
+	schema := makeTestVariable(acctest.RandString(5))
+	name := makeTestVariable(acctest.RandString(5))
+	nameOther:=makeTestVariable(acctest.RandString(5))
+	resourceName := "mso_schema_template_bd_dhcp_policy.test"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckMSOSchemaTemplateBDDHCPDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: CreateMSOSchemaTemplateBDDHCPPolicyWithoutRequired(tenantNames[0],schema,name),
+				Config:      CreateMSOSchemaTemplateBDDHCPPolicyWithoutRequired(tenantNames[0], schema, name, "schema_id"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateMSOSchemaTemplateBDDHCPPolicyWithoutRequired(tenantNames[0], schema, name, "template_name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateMSOSchemaTemplateBDDHCPPolicyWithoutRequired(tenantNames[0], schema, name, "bd_name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateMSOSchemaTemplateBDDHCPPolicyWithoutRequired(tenantNames[0], schema, name, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateMSOSchemaTemplateBDDHCPPolicyWithRequired(tenantNames[0], schema, name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMSOSchemaTemplateBDDHCPPolicyExists(resourceName, &pol1),
+					resource.TestCheckResourceAttr(resourceName, "bd_name", name),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "template_name", schema),
+					resource.TestCheckResourceAttr(resourceName, "dhcp_option_name", ""),
+					resource.TestCheckResourceAttr(resourceName, "dhcp_option_version", "0"),
+					resource.TestCheckResourceAttr(resourceName, "version", "0"),
+					resource.TestCheckResourceAttrSet(resourceName, "schema_id"),
+				),
+			},{
+				Config: CreateMSOSchemaTemplateBDDHCPPolicyWithOptionalValues(tenantNames[0], schema, name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMSOSchemaTemplateBDDHCPPolicyExists(resourceName, &pol1),
+					resource.TestCheckResourceAttr(resourceName, "bd_name", name),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "template_name", schema),
+					resource.TestCheckResourceAttr(resourceName, "dhcp_option_name", ""),
+					resource.TestCheckResourceAttr(resourceName, "dhcp_option_version", "0"),
+					resource.TestCheckResourceAttr(resourceName, "version", "0"),
+					resource.TestCheckResourceAttrSet(resourceName, "schema_id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: CreateMSOSchemaTemplateBDDHCPPolicyWithRequired(tenantNames[0], schema, nameOther),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMSOSchemaTemplateBDDHCPPolicyExists(resourceName, &pol1),
+					resource.TestCheckResourceAttr(resourceName, "bd_name", nameOther),
+					resource.TestCheckResourceAttr(resourceName, "name", nameOther),
+					resource.TestCheckResourceAttr(resourceName, "template_name", schema),
+					resource.TestCheckResourceAttr(resourceName, "dhcp_option_name", ""),
+					resource.TestCheckResourceAttr(resourceName, "dhcp_option_version", "0"),
+					resource.TestCheckResourceAttr(resourceName, "version", "0"),
+					resource.TestCheckResourceAttrSet(resourceName, "schema_id"),
+				),
 			},
 		},
 	})
 }
 
-func CreateMSOSchemaTemplateBDDHCPPolicyWithoutRequired(tenant,schema,name string) string{
-	resource:=GetParentConfigBDDHCPPolicy(tenant,schema,name)
+func CreateMSOSchemaTemplateBDDHCPPolicyWithOptionalValues(tenant,scheme,name string) string{
+	resource := GetParentConfigBDDHCPPolicy(tenant, scheme, name)
+	resource += fmt.Sprintln(`
+	resource "mso_schema_template_bd_dhcp_policy" "test" {
+		schema_id           = mso_schema.test.id
+		template_name       = mso_schema.test.template_name
+		bd_name             = mso_schema_template_bd.test.name
+		name                = mso_dhcp_relay_policy.test.name
+	}
+	`)
+}
+
+func CreateMSOSchemaTemplateBDDHCPPolicyWithRequired(tenant, scheme, name string) string {
+	resource := GetParentConfigBDDHCPPolicy(tenant, scheme, name)
+	resource += fmt.Sprintln(`
+	resource "mso_schema_template_bd_dhcp_policy" "test" {
+		schema_id           = mso_schema.test.id
+		template_name       = mso_schema.test.template_name
+		bd_name             = mso_schema_template_bd.test.name
+		name                = mso_dhcp_relay_policy.test.name
+	}
+	`)
 	return resource
+}
+
+func CreateMSOSchemaTemplateBDDHCPPolicyWithoutRequired(tenant, schema, name, attr string) string {
+	rBlock := GetParentConfigBDDHCPPolicy(tenant, schema, name)
+	switch attr {
+	case "schema_id":
+		rBlock += `
+		resource "mso_schema_template_bd_dhcp_policy" "test" {
+		#	schema_id           = mso_schema.test.id
+			template_name       = mso_schema.test.template_name
+			bd_name             = mso_schema_template_bd.test.name
+			name                = mso_dhcp_relay_policy.test.name
+		}
+		`
+	case "template_name":
+		rBlock += `
+		resource "mso_schema_template_bd_dhcp_policy" "test" {
+			schema_id           = mso_schema.test.id
+		#	template_name       = mso_schema.test.template_name
+			bd_name             = mso_schema_template_bd.test.name
+			name                = mso_dhcp_relay_policy.test.name
+		}
+		`
+	case "bd_name":
+		rBlock += `
+		resource "mso_schema_template_bd_dhcp_policy" "test" {
+			schema_id           = mso_schema.test.id
+			template_name       = mso_schema.test.template_name
+		#	bd_name             = mso_schema_template_bd.test.name
+			name                = mso_dhcp_relay_policy.test.name
+		}
+		`
+	case "name":
+		rBlock += `
+		resource "mso_schema_template_bd_dhcp_policy" "test" {
+			schema_id           = mso_schema.test.id
+			template_name       = mso_schema.test.template_name
+			bd_name             = mso_schema_template_bd.test.name
+		#	name                = mso_dhcp_relay_policy.test.name
+		}
+		`
+	}
+	return fmt.Sprintln(rBlock)
 }
 
 // func TestAccMSOSchemaTemplateBD_Update(t *testing.T) {
@@ -100,7 +222,7 @@ func testAccCheckMSOSchemaTemplateBDDHCPDestroy(s *terraform.State) error {
 		if rs.Type == "mso_schema_template_bd_dhcp_policy" {
 			BDDHCPPolicyModel := modelFromMSOTemplateBDDHCPPolicyId(rs.Primary.ID)
 			_, err := getMSOTemplateBDDHCPPolicy(client, BDDHCPPolicyModel)
-			if err != nil {
+			if err == nil {
 				return fmt.Errorf("Schema Template BD DHCP Policy with id %s still exists", rs.Primary.ID)
 			}
 		}

--- a/mso/resource_mso_schema_template_bd_dhcp_policy_test.go
+++ b/mso/resource_mso_schema_template_bd_dhcp_policy_test.go
@@ -16,7 +16,7 @@ func TestAccMSOSchemaTemplateBDDHCPPolicy_Basic(t *testing.T) {
 	var pol1 models.TemplateBDDHCPPolicy
 	schema := makeTestVariable(acctest.RandString(5))
 	name := makeTestVariable(acctest.RandString(5))
-	nameOther:=makeTestVariable(acctest.RandString(5))
+	nameOther := makeTestVariable(acctest.RandString(5))
 	resourceName := "mso_schema_template_bd_dhcp_policy.test"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -51,7 +51,7 @@ func TestAccMSOSchemaTemplateBDDHCPPolicy_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "version", "0"),
 					resource.TestCheckResourceAttrSet(resourceName, "schema_id"),
 				),
-			},{
+			}, {
 				Config: CreateMSOSchemaTemplateBDDHCPPolicyWithOptionalValues(tenantNames[0], schema, name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMSOSchemaTemplateBDDHCPPolicyExists(resourceName, &pol1),
@@ -86,16 +86,24 @@ func TestAccMSOSchemaTemplateBDDHCPPolicy_Basic(t *testing.T) {
 	})
 }
 
-func CreateMSOSchemaTemplateBDDHCPPolicyWithOptionalValues(tenant,scheme,name string) string{
+func CreateMSOSchemaTemplateBDDHCPPolicyWithOptionalValues(tenant, scheme, name string) string {
 	resource := GetParentConfigBDDHCPPolicy(tenant, scheme, name)
-	resource += fmt.Sprintln(`
+	resource += fmt.Sprintf(`
+	resource "mso_dhcp_option_policy" "example" {
+		tenant_id   = mso_tenant.tenant1.id
+		name        = "%s"
+	}
 	resource "mso_schema_template_bd_dhcp_policy" "test" {
 		schema_id           = mso_schema.test.id
 		template_name       = mso_schema.test.template_name
 		bd_name             = mso_schema_template_bd.test.name
 		name                = mso_dhcp_relay_policy.test.name
+		dhcp_option_name    = mso_dhcp_option_policy.example.name
+		version             = 1
+		dhcp_option_version = 1
 	}
-	`)
+	`, name)
+	return resource
 }
 
 func CreateMSOSchemaTemplateBDDHCPPolicyWithRequired(tenant, scheme, name string) string {


### PR DESCRIPTION
$ go test -v -run TestAccMSOSchemaTemplateBDDHCPPolicy -timeout=60m
=== RUN   TestAccMSOSchemaTemplateBDDHCPPolicy_DataSource
=== PAUSE TestAccMSOSchemaTemplateBDDHCPPolicy_DataSource
=== RUN   TestAccMSOSchemaTemplateBDDHCPPolicy_Basic
=== PAUSE TestAccMSOSchemaTemplateBDDHCPPolicy_Basic
=== RUN   TestAccMSOSchemaTemplateBDDHCPPolicy_Negtive
=== PAUSE TestAccMSOSchemaTemplateBDDHCPPolicy_Negtive
=== CONT  TestAccMSOSchemaTemplateBDDHCPPolicy_DataSource
=== CONT  TestAccMSOSchemaTemplateBDDHCPPolicy_Negtive
=== CONT  TestAccMSOSchemaTemplateBDDHCPPolicy_Basic
--- PASS: TestAccMSOSchemaTemplateBDDHCPPolicy_Negtive (12.47s)
--- PASS: TestAccMSOSchemaTemplateBDDHCPPolicy_DataSource (14.58s)
--- PASS: TestAccMSOSchemaTemplateBDDHCPPolicy_Basic (26.68s)
PASS
ok      github.com/terraform-providers/terraform-provider-mso/mso       27.404s